### PR TITLE
feat: align client fallback with Nuxt 4 async-data behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ The current implementation is maintained around these guarantees:
 - reactive `key`, `baseURL`, `params`, `query`, `headers`, `body`, and `cache` values are resolved before each request
 - generated keys include both `params` and `query`, which avoids stale client reuse when only one side changes
 - same-key client compatibility requests share one async-data bucket, so `dedupe: 'cancel'` can abort the previous pending request
+- the client compatibility path mirrors Nuxt 4 async-data behavior: `pending` follows the `pendingWhenIdle` config, `refreshNuxtData()` (the `app:data:refresh` hook) re-runs fallback requests, `getCachedData` is honored and successful data is written back to `nuxtApp.payload.data`
+- timeouts and external abort signals are merged into one request signal (via `AbortSignal.timeout`/`AbortSignal.any` semantics), key watchers are only created for reactive keys, and a key change re-runs the request when `immediate`, prior data, or an in-flight request is present
 - Vitest runtime tests and TypeScript type tests cover the wrapper behavior
 
 ## When To Use This Module
@@ -103,8 +105,8 @@ Always `await` `ajax.get`, `ajax.post`, and `ajax.request` in setup-compatible c
 ## Reactive Example
 
 ```ts
-import { computed, ref } from 'vue'
 import { CustomFetch } from '#imports'
+import { computed, ref } from 'vue'
 
 const ajax = new CustomFetch({ baseURL: '/api' })
 
@@ -142,7 +144,7 @@ export const getGreetingByUserId = (key: MaybeRefOrGetter<string>, { userId = 1 
     default: () => '11'
   })
 
-export function getReactivePageList(page: Ref<number>) {
+export function getReactivePageList (page: Ref<number>) {
   return ajax.get<{ data: number[], nums: number }>('/get-list', {
     params: { page }
   }, {

--- a/src/runtime/ajax.ts
+++ b/src/runtime/ajax.ts
@@ -3,8 +3,8 @@ import type { NitroFetchRequest } from 'nitro/types'
 import type { AsyncData, AsyncDataOptions, NuxtError } from 'nuxt/app'
 import type { CustomFetchOptions, CustomFetchRequestOptions, FetchContext, FetchResponse, Interceptors, KeysOf, PickFrom, ResolvedCustomFetchOptions } from './type'
 // @ts-expect-error virtual file
-import { asyncDataDefaults } from '#build/nuxt.config.mjs'
-import { clearNuxtData, computed, createError, getCurrentScope, onScopeDispose, reactive, ref, shallowRef, toValue, unref, useAsyncData, useNuxtApp, useRequestFetch, useRuntimeConfig, watch } from '#imports'
+import { asyncDataDefaults, granularCachedData, pendingWhenIdle } from '#build/nuxt.config.mjs'
+import { clearNuxtData, computed, createError, getCurrentScope, isRef, onScopeDispose, reactive, ref, shallowRef, toValue, unref, useAsyncData, useNuxtApp, useRequestFetch, useRuntimeConfig, watch } from '#imports'
 import { hash, serialize } from 'ohash'
 import { generateOptionSegments, Noop, pick, resolveReactiveValue } from './utils'
 
@@ -37,6 +37,14 @@ interface NuxtAppWithAsyncData {
     _deps?: number
     execute?: (opts?: AsyncDataExecuteOptions) => Promise<unknown>
   } | undefined>
+  payload?: {
+    data?: Record<string, unknown>
+    _errors?: Record<string, unknown>
+  }
+  static?: {
+    data?: Record<string, unknown>
+  }
+  hook?: (name: string, callback: (...args: any[]) => unknown) => (() => void)
 }
 
 interface ClientAsyncDataEntry {
@@ -71,11 +79,37 @@ function linkAbortSignal (signal: AbortSignal | undefined, controller: AbortCont
   }
 
   if (signal.aborted) {
-    controller.abort()
+    controller.abort((signal as AbortSignal).reason)
     return
   }
 
-  signal.addEventListener('abort', () => controller.abort(), { once: true })
+  signal.addEventListener('abort', () => controller.abort((signal as AbortSignal).reason), { once: true })
+}
+
+/**
+ * Merge the provided signals (plus an optional timeout) into a single signal,
+ * mirroring Nuxt's `mergeAbortSignals`. Always backed by a dedicated controller
+ * so the request still receives an abort signal when the async-data context does
+ * not provide one, and returns `undefined` when `AbortController` is unavailable.
+ */
+function createMergedSignal (signals: Array<AbortSignal | undefined>, timeout?: number) {
+  const controller = createAbortController()
+
+  if (!controller) {
+    return undefined
+  }
+
+  const sources = signals.filter((signal): signal is AbortSignal => !!signal)
+
+  if (typeof timeout === 'number' && timeout >= 0 && typeof AbortSignal !== 'undefined' && typeof AbortSignal.timeout === 'function') {
+    sources.push(AbortSignal.timeout(timeout))
+  }
+
+  for (const signal of sources) {
+    linkAbortSignal(signal, controller)
+  }
+
+  return controller.signal
 }
 
 function shouldFallbackToClientAsyncData (error: unknown) {
@@ -163,7 +197,8 @@ export class CustomFetch {
     const baseConfig = this.baseConfig(config)
     const baseURL = toValue(rawConfig.baseURL)
     const body = resolveReactiveValue<ResolvedRequestFetchOptions['body']>(toValue(rawConfig.body))
-    const cache = toValue(rawConfig.cache)
+    const _cache = toValue(rawConfig.cache)
+    const cache = typeof _cache === 'boolean' ? undefined : _cache
     const headers = resolveReactiveValue<ResolvedRequestFetchOptions['headers']>(toValue(rawConfig.headers))
     const method = toValue(rawConfig.method)
     const params = resolveReactiveValue<ResolvedRequestFetchOptions['params']>(toValue(baseConfig.params ?? rawConfig.params))
@@ -320,13 +355,13 @@ export class CustomFetch {
     const key = computed(() => toValue(resolvedConfig.key) || hashKey)
 
     const executeRequest = (executeOptions: AsyncDataExecuteOptions = {}) => {
-      const controller = createAbortController()
-      linkAbortSignal(executeOptions.signal, controller)
+      const timeout = executeOptions.timeout ?? options.timeout
+      const signal = createMergedSignal([executeOptions.signal], timeout)
 
       return requestFetch(url as string, {
         ...defaultOptions,
-        ...getResolvedFetchConfig(executeOptions.timeout ?? options.timeout),
-        signal: controller?.signal
+        ...getResolvedFetchConfig(timeout),
+        signal
       }) as unknown as Promise<ResT>
     }
 
@@ -337,8 +372,11 @@ export class CustomFetch {
       })
     }
 
+    const nuxtApp = useNuxtApp() as NuxtAppWithAsyncData
+
     const createClientAsyncDataFallback = (): CustomFetchReturnValue<DataT, PickKeys, DefaultT, NuxtErrorDataT> => {
       const _ref = options.deep ? ref : shallowRef
+      const usePendingRef = pendingWhenIdle
       const getDefaultValue = () => {
         if (options.default) {
           return unref(options.default()) as CustomFetchData<DataT, PickKeys, DefaultT>
@@ -347,24 +385,65 @@ export class CustomFetch {
         return asyncDataDefaults.value as CustomFetchData<DataT, PickKeys, DefaultT>
       }
 
+      const resolveCachedData = (cause: AsyncDataRefreshCause = 'refresh:manual') => {
+        if (options.getCachedData) {
+          return options.getCachedData(key.value, nuxtApp as any, { cause }) as CustomFetchData<DataT, PickKeys, DefaultT> | undefined
+        }
+
+        if (nuxtApp.isHydrating) {
+          return nuxtApp.payload?.data?.[key.value] as CustomFetchData<DataT, PickKeys, DefaultT> | undefined
+        }
+
+        if (cause !== 'refresh:manual' && cause !== 'refresh:hook') {
+          return nuxtApp.static?.data?.[key.value] as CustomFetchData<DataT, PickKeys, DefaultT> | undefined
+        }
+
+        return undefined
+      }
+
+      const writePayloadData = (value: CustomFetchData<DataT, PickKeys, DefaultT>) => {
+        if (nuxtApp.payload?.data) {
+          nuxtApp.payload.data[key.value] = value
+        }
+      }
+
+      const isKeyReactive = isRef(resolvedConfig.key) || typeof resolvedConfig.key === 'function'
+
       let activeController: AbortController | undefined
       let activeRequest: Promise<void> | undefined
       let requestId = 0
+      let hasData = false
+      let keyChanging = false
       let stopKeyWatch: (() => void) | undefined
       let stopOptionWatch: (() => void) | undefined
+      let stopRefreshHook: (() => void) | undefined
+
+      const initialStatus = options.immediate === false ? 'idle' : 'pending'
+      const statusRef = _ref(initialStatus) as Ref<'idle' | 'pending' | 'success' | 'error'>
+      const pendingRef = (usePendingRef
+        ? _ref(initialStatus === 'pending')
+        : computed(() => statusRef.value === 'pending')) as Ref<boolean>
+
+      const setPending = (value: boolean) => {
+        if (usePendingRef) {
+          pendingRef.value = value
+        }
+      }
 
       const stopWatchers = () => {
         stopKeyWatch?.()
         stopKeyWatch = undefined
         stopOptionWatch?.()
         stopOptionWatch = undefined
+        stopRefreshHook?.()
+        stopRefreshHook = undefined
       }
 
       const asyncData: CustomFetchAsyncDataState<DataT, PickKeys, DefaultT, NuxtErrorDataT> = {
         data: _ref(getDefaultValue()) as Ref<CustomFetchData<DataT, PickKeys, DefaultT>>,
         error: _ref(asyncDataDefaults.errorValue) as Ref<CustomFetchError<NuxtErrorDataT>>,
-        status: _ref(options.immediate === false ? 'idle' : 'pending'),
-        pending: _ref(options.immediate !== false),
+        status: statusRef,
+        pending: pendingRef,
         clear: () => {
           stopWatchers()
           activeController?.abort()
@@ -372,16 +451,18 @@ export class CustomFetch {
           if (_cachedClientAsyncData.get(key.value) === asyncData) {
             _cachedClientAsyncData.delete(key.value)
           }
+          hasData = false
           asyncData.data.value = getDefaultValue()
           asyncData.error.value = asyncDataDefaults.errorValue
           asyncData.status.value = 'idle'
-          asyncData.pending.value = false
+          setPending(false)
           clearNuxtData(key.value)
         },
         refresh: async (executeOptions?: AsyncDataExecuteOptions) => {
           await asyncData.execute(executeOptions)
         },
         execute: async (executeOptions?: AsyncDataExecuteOptions) => {
+          const cause = executeOptions?.cause
           const dedupe = executeOptions?.dedupe ?? options.dedupe ?? 'cancel'
           if (activeRequest) {
             if (dedupe === 'defer') {
@@ -389,6 +470,19 @@ export class CustomFetch {
             }
 
             activeController?.abort()
+          }
+
+          if (granularCachedData || cause === 'initial' || nuxtApp.isHydrating) {
+            const cachedData = resolveCachedData(cause)
+            if (cachedData !== undefined) {
+              writePayloadData(cachedData)
+              hasData = true
+              asyncData.data.value = cachedData
+              asyncData.error.value = asyncDataDefaults.errorValue
+              asyncData.status.value = 'success'
+              setPending(false)
+              return
+            }
           }
 
           const currentRequestId = ++requestId
@@ -400,7 +494,7 @@ export class CustomFetch {
             _cachedController.set(key.value, controller)
           }
 
-          asyncData.pending.value = true
+          setPending(true)
           asyncData.status.value = 'pending'
           asyncData.error.value = asyncDataDefaults.errorValue
 
@@ -423,7 +517,10 @@ export class CustomFetch {
                 finalData = pick(data as Record<string, any>, options.pick as string[]) as PickFrom<DataT, PickKeys>
               }
 
-              asyncData.data.value = finalData as CustomFetchData<DataT, PickKeys, DefaultT>
+              const value = finalData as CustomFetchData<DataT, PickKeys, DefaultT>
+              writePayloadData(value)
+              hasData = true
+              asyncData.data.value = value
               asyncData.error.value = asyncDataDefaults.errorValue
               asyncData.status.value = 'success'
             })
@@ -432,6 +529,7 @@ export class CustomFetch {
                 return
               }
 
+              hasData = false
               asyncData.error.value = createError(error) as CustomFetchError<NuxtErrorDataT>
               asyncData.data.value = getDefaultValue()
               asyncData.status.value = 'error'
@@ -449,7 +547,7 @@ export class CustomFetch {
                 asyncData.status.value = 'idle'
               }
 
-              asyncData.pending.value = false
+              setPending(false)
             })
 
           await activeRequest
@@ -458,28 +556,51 @@ export class CustomFetch {
 
       _cachedClientAsyncData.set(key.value, asyncData as ClientAsyncDataEntry)
 
-      stopKeyWatch = watch(key, (newKey, oldKey) => {
-        if (oldKey) {
-          _cachedController.get(oldKey)?.abort?.()
-          _cachedController.delete(oldKey)
-
-          if (_cachedClientAsyncData.get(oldKey) === asyncData) {
-            _cachedClientAsyncData.delete(oldKey)
-          }
-        }
-
-        if (newKey !== oldKey) {
-          _cachedClientAsyncData.set(newKey, asyncData as ClientAsyncDataEntry)
-        }
-
-        if (newKey !== oldKey && options.immediate !== false) {
-          void asyncData.execute({ cause: 'watch' })
+      stopRefreshHook = nuxtApp.hook?.('app:data:refresh', async (keys?: string[]) => {
+        if (!keys || keys.includes(key.value)) {
+          await asyncData.execute({ cause: 'refresh:hook' })
         }
       })
+
+      if (isKeyReactive) {
+        stopKeyWatch = watch(key, (newKey, oldKey) => {
+          if (!((newKey || oldKey) && newKey !== oldKey)) {
+            return
+          }
+
+          keyChanging = true
+          const hadData = hasData
+          const wasRunning = activeRequest !== undefined
+
+          if (oldKey) {
+            _cachedController.get(oldKey)?.abort?.()
+            _cachedController.delete(oldKey)
+
+            if (_cachedClientAsyncData.get(oldKey) === asyncData) {
+              _cachedClientAsyncData.delete(oldKey)
+            }
+          }
+
+          _cachedClientAsyncData.set(newKey, asyncData as ClientAsyncDataEntry)
+
+          const keyTriggersExecute = (options as { _keyTriggersExecute?: boolean })._keyTriggersExecute !== false
+          if (keyTriggersExecute && (options.immediate !== false || hadData || wasRunning)) {
+            void asyncData.execute({ cause: 'watch' })
+          }
+
+          void Promise.resolve().then(() => {
+            keyChanging = false
+          })
+        }, { flush: 'sync' })
+      }
 
       const hasScope = getCurrentScope()
       if (options.watch) {
         stopOptionWatch = watch(options.watch, async () => {
+          if (keyChanging) {
+            return
+          }
+
           await asyncData.refresh({ cause: 'watch' })
         }, { flush: 'post' })
       }
@@ -499,7 +620,6 @@ export class CustomFetch {
       return asyncData.execute({ cause: 'initial' }).then(() => asyncData) as CustomFetchReturnValue<DataT, PickKeys, DefaultT, NuxtErrorDataT>
     }
 
-    const nuxtApp = useNuxtApp() as NuxtAppWithAsyncData
     const sharedAsyncData = nuxtApp._asyncData?.[key.value]
     const cachedClientAsyncData = _cachedClientAsyncData.get(key.value)
 

--- a/test/ajax.test.ts
+++ b/test/ajax.test.ts
@@ -2,7 +2,7 @@ import type { AsyncDataOptions } from 'nuxt/app'
 import { ref } from '#imports'
 import { computed } from 'vue'
 import { CustomFetch } from '../src/runtime/ajax'
-import { asyncDataDefaults } from './mocks/nuxt-config'
+import { __setPendingWhenIdle, asyncDataDefaults } from './mocks/nuxt-config'
 import { __getNuxtMockState, __setNuxtApp, __setRequestFetchImpl, __setRuntimeConfig, __setUseAsyncDataImpl } from './mocks/nuxt-imports'
 
 function createAsyncDataResult<DataT> (data: DataT) {
@@ -895,6 +895,10 @@ describe('customFetch', () => {
     const page = ref(1)
     const search = ref('nuxt')
 
+    __setNuxtApp({
+      isHydrating: false,
+      _asyncData: {}
+    })
     __setRequestFetchImpl(requestFetch)
     __setUseAsyncDataImpl(() => {
       throw new Error('outside of a plugin')
@@ -1092,11 +1096,19 @@ describe('customFetch', () => {
         count: 3,
         extra: 'second'
       })
+      .mockResolvedValueOnce({
+        count: 4,
+        extra: 'third'
+      })
     const key = ref('fallback:1')
     const watchedSource = ref(1)
     const mockState = __getNuxtMockState()
 
     mockState.currentScope = {}
+    __setNuxtApp({
+      isHydrating: false,
+      _asyncData: {}
+    })
     __setRequestFetchImpl(requestFetch)
     __setUseAsyncDataImpl(() => {
       throw new Error('Component is already mounted')
@@ -1131,13 +1143,15 @@ describe('customFetch', () => {
     expect(asyncData.data.value).toEqual({ count: 2 })
     expect(asyncData.status.value).toBe('success')
 
+    // A key change re-runs the request when data already exists, matching
+    // Nuxt's `keyTriggersExecute && (immediate || hadData || wasRunning)` rule.
     key.value = 'fallback:2'
     await keyWatch?.callback('fallback:2', 'fallback:1')
-    expect(asyncData.data.value).toEqual({ count: 2 })
+    expect(asyncData.data.value).toEqual({ count: 3 })
 
     watchedSource.value = 2
     await sourceWatch?.callback()
-    expect(asyncData.data.value).toEqual({ count: 3 })
+    expect(asyncData.data.value).toEqual({ count: 4 })
 
     asyncData.clear()
     expect(asyncData.data.value).toEqual({ count: 0 })
@@ -1335,7 +1349,6 @@ describe('customFetch', () => {
     const requestFetch = vi.fn().mockResolvedValue({ count: 1 })
     const mockState = __getNuxtMockState()
     const entries: unknown[] = []
-    const initialWatchStopCalls = mockState.watchStopCalls
 
     __setRequestFetchImpl(requestFetch)
     __setUseAsyncDataImpl(() => {
@@ -1355,7 +1368,8 @@ describe('customFetch', () => {
       }))
     }
 
-    expect(mockState.watchStopCalls).toBeGreaterThan(initialWatchStopCalls)
+    // The oldest entry is cleared once the cache exceeds its cap.
+    expect(mockState.clearNuxtDataCalls).toContain('fallback:cache:0')
 
     const recreatedEntry = await ajax.get<{ count: number }>('/hello', {
       key: 'fallback:cache:0'
@@ -1453,5 +1467,139 @@ describe('customFetch', () => {
     })
 
     expect(() => ajax.get('/hello')).toThrow('boom')
+  })
+
+  it('refreshes fallback data when the app:data:refresh hook fires', async () => {
+    const requestFetch = vi
+      .fn()
+      .mockResolvedValueOnce({ count: 1 })
+      .mockResolvedValueOnce({ count: 2 })
+    const mockState = __getNuxtMockState()
+
+    __setNuxtApp({
+      isHydrating: false,
+      _asyncData: {}
+    })
+    __setRequestFetchImpl(requestFetch)
+    __setUseAsyncDataImpl(() => {
+      throw new Error('outside of a plugin')
+    })
+
+    const ajax = new CustomFetch({
+      baseURL: '/api',
+      showLogs: false
+    })
+    const asyncData = await ajax.get<{ count: number }>('/hello', {
+      key: 'hook:key'
+    }, {
+      default: () => ({ count: 0 })
+    })
+
+    expect(asyncData.data.value).toEqual({ count: 1 })
+
+    await mockState.nuxtApp.callHook('app:data:refresh', ['other:key'])
+    expect(asyncData.data.value).toEqual({ count: 1 })
+
+    await mockState.nuxtApp.callHook('app:data:refresh')
+    expect(asyncData.data.value).toEqual({ count: 2 })
+  })
+
+  it('serves getCachedData without fetching in the client fallback', async () => {
+    const requestFetch = vi.fn().mockResolvedValue({ count: 9 })
+
+    __setNuxtApp({
+      isHydrating: false,
+      _asyncData: {}
+    })
+    __setRequestFetchImpl(requestFetch)
+    __setUseAsyncDataImpl(() => {
+      throw new Error('outside of a plugin')
+    })
+
+    const ajax = new CustomFetch({
+      baseURL: '/api',
+      showLogs: false
+    })
+    const asyncData = await ajax.get<{ count: number }>('/hello', {
+      key: 'cache:key'
+    }, {
+      default: () => ({ count: 0 }),
+      getCachedData: () => ({ count: 42 })
+    })
+
+    expect(asyncData.data.value).toEqual({ count: 42 })
+    expect(asyncData.status.value).toBe('success')
+    expect(requestFetch).not.toHaveBeenCalled()
+  })
+
+  it('writes successful fallback data back to the nuxt payload', async () => {
+    const requestFetch = vi.fn().mockResolvedValue({ count: 7 })
+    const mockState = __getNuxtMockState()
+
+    __setNuxtApp({
+      isHydrating: false,
+      _asyncData: {}
+    })
+    __setRequestFetchImpl(requestFetch)
+    __setUseAsyncDataImpl(() => {
+      throw new Error('outside of a plugin')
+    })
+
+    const ajax = new CustomFetch({
+      baseURL: '/api',
+      showLogs: false
+    })
+    await ajax.get<{ count: number }>('/hello', {
+      key: 'payload:key'
+    }, {
+      default: () => ({ count: 0 })
+    })
+
+    expect(mockState.nuxtApp.payload.data['payload:key']).toEqual({ count: 7 })
+  })
+
+  it('uses a standalone pending ref when pendingWhenIdle is enabled', async () => {
+    __setPendingWhenIdle(true)
+
+    try {
+      let resolveRequest: ((value: { count: number }) => void) | undefined
+      const requestFetch = vi.fn(() => new Promise<{ count: number }>((resolve) => {
+        resolveRequest = resolve
+      }))
+
+      __setNuxtApp({
+        isHydrating: false,
+        _asyncData: {}
+      })
+      __setRequestFetchImpl(requestFetch)
+      __setUseAsyncDataImpl(() => {
+        throw new Error('outside of a plugin')
+      })
+
+      const ajax = new CustomFetch({
+        baseURL: '/api',
+        showLogs: false
+      })
+      const asyncData = await ajax.get<{ count: number }>('/hello', {
+        key: 'pending:key'
+      }, {
+        default: () => ({ count: 0 }),
+        immediate: false
+      })
+
+      expect(asyncData.pending.value).toBe(false)
+
+      const executePromise = asyncData.execute()
+      expect(asyncData.pending.value).toBe(true)
+
+      resolveRequest?.({ count: 1 })
+      await executePromise
+
+      expect(asyncData.pending.value).toBe(false)
+      expect(asyncData.status.value).toBe('success')
+    }
+    finally {
+      __setPendingWhenIdle(false)
+    }
   })
 })

--- a/test/mocks/nuxt-config.ts
+++ b/test/mocks/nuxt-config.ts
@@ -1,7 +1,24 @@
+/* eslint-disable import/no-mutable-exports -- test mock mirrors Nuxt's mutable virtual config flags */
 export const asyncDataDefaults: {
   value: unknown
   errorValue: unknown
 } = {
   value: undefined,
   errorValue: undefined
+}
+
+export let pendingWhenIdle = false
+export let granularCachedData = true
+export let purgeCachedData = true
+
+export function __setPendingWhenIdle (value: boolean) {
+  pendingWhenIdle = value
+}
+
+export function __setGranularCachedData (value: boolean) {
+  granularCachedData = value
+}
+
+export function __setPurgeCachedData (value: boolean) {
+  purgeCachedData = value
 }

--- a/test/mocks/nuxt-imports.ts
+++ b/test/mocks/nuxt-imports.ts
@@ -10,12 +10,23 @@ interface WatchCall {
 
 type UseAsyncDataImpl = (...args: any[]) => any
 type RequestFetchImpl = (...args: any[]) => Promise<unknown>
+type HookCallback = (...args: any[]) => unknown
 interface NuxtAppState {
   isHydrating: boolean
   _asyncData: Record<string, {
     _deps?: number
     execute?: (opts?: unknown) => Promise<unknown>
   } | undefined>
+  payload: {
+    data: Record<string, unknown>
+    _errors: Record<string, unknown>
+  }
+  static: {
+    data: Record<string, unknown>
+  }
+  _hooks: Record<string, Set<HookCallback>>
+  hook: (name: string, callback: HookCallback) => () => void
+  callHook: (name: string, ...args: unknown[]) => Promise<void>
 }
 
 function isRefLike<T> (value: unknown): value is MockRef<T> {
@@ -38,13 +49,38 @@ function unwrapValue<T> (value: T): T {
   return unwrapRef(value)
 }
 
+function createNuxtApp (): NuxtAppState {
+  const _hooks: Record<string, Set<HookCallback>> = {}
+
+  return {
+    isHydrating: true,
+    _asyncData: {},
+    payload: {
+      data: {},
+      _errors: {}
+    },
+    static: {
+      data: {}
+    },
+    _hooks,
+    hook (name: string, callback: HookCallback) {
+      (_hooks[name] ??= new Set()).add(callback)
+      return () => {
+        _hooks[name]?.delete(callback)
+      }
+    },
+    async callHook (name: string, ...args: unknown[]) {
+      for (const callback of _hooks[name] ?? []) {
+        await callback(...args)
+      }
+    }
+  }
+}
+
 function createInitialState () {
   return {
     runtimeConfig: { app: { baseURL: '/runtime-base' } },
-    nuxtApp: {
-      isHydrating: true,
-      _asyncData: {}
-    } as NuxtAppState,
+    nuxtApp: createNuxtApp(),
     requestFetch: (async () => undefined) as RequestFetchImpl,
     useAsyncData: (async (key: unknown, handler: unknown, options: unknown) => ({
       key,
@@ -78,8 +114,14 @@ export function __setRuntimeConfig (runtimeConfig: typeof state.runtimeConfig) {
   state.runtimeConfig = runtimeConfig
 }
 
-export function __setNuxtApp (nuxtApp: typeof state.nuxtApp) {
-  state.nuxtApp = nuxtApp
+export function __setNuxtApp (nuxtApp: Partial<NuxtAppState> & Pick<NuxtAppState, 'isHydrating' | '_asyncData'>) {
+  const base = createNuxtApp()
+  state.nuxtApp = {
+    ...base,
+    ...nuxtApp,
+    payload: nuxtApp.payload ?? base.payload,
+    static: nuxtApp.static ?? base.static
+  }
 }
 
 export function __setUseAsyncDataImpl (implementation: UseAsyncDataImpl) {
@@ -120,6 +162,10 @@ export function onScopeDispose (callback: () => void) {
 
 export function reactive<T extends object> (value: T) {
   return value
+}
+
+export function isRef (value: unknown): boolean {
+  return isRefLike(value)
 }
 
 export function ref<T> (value: T): MockRef<T> {


### PR DESCRIPTION
Bring the post-mount client compatibility path in line with Nuxt 4's
useAsyncData implementation:

- pending follows the pendingWhenIdle config (computed from status by
  default instead of an always-standalone ref)
- register the app:data:refresh hook so refreshNuxtData() re-runs
  fallback requests
- honor getCachedData and write successful data back to
  nuxtApp.payload.data so it is shared with useNuxtData
- merge timeout and external abort signals into a single request signal
  via AbortSignal.timeout/any semantics
- only create the key watcher for reactive keys (isKeyReactive)
- re-run on key change when immediate, prior data, or an in-flight
  request is present (keyTriggersExecute)
- normalize boolean cache values to undefined

Also fix pre-existing lint errors in the README examples.